### PR TITLE
Update stale LinkedIn follower count (20K+ → 26K+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## About the Program
 
-**DevOps Micro Internship with Agentic AI** is a 14-week mentor-led cohort program by [Pravin Mishra](https://www.linkedin.com/in/pravin-mishra-aws-trainer/) — Cloud, DevOps & AI consultant with 15+ years of experience, 5,000+ learners trained, and 20K+ LinkedIn followers.
+**DevOps Micro Internship with Agentic AI** is a 14-week mentor-led cohort program by [Pravin Mishra](https://www.linkedin.com/in/pravin-mishra-aws-trainer/) — Cloud, DevOps & AI consultant with 15+ years of experience, 5,000+ learners trained, and 26K+ LinkedIn followers.
 
 This is not a course. It is an internship-style program — real deployments, real pipelines, real evidence reviewed by mentors every week.
 


### PR DESCRIPTION
One-line fix from the hub rework spec (`dmi-growth/dmi-hub-rework-spec.md` Task 1d): the README stated 20K+ LinkedIn followers; actual is 26K+. Same fix shipped on the hub in dmi.pravinmishra.com#55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)